### PR TITLE
Drops underline from links

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -112,7 +112,6 @@ a {
 
   &:hover {
     color: $text-color;
-    text-decoration: underline;
   }
 
   .social-media-list &:hover {


### PR DESCRIPTION
It looks a bit better in my opinion, interested in feedback

<img width="597" alt="Screen Shot 2020-03-27 at 2 33 45 PM" src="https://user-images.githubusercontent.com/55107443/77788708-1f126480-7038-11ea-8fb5-f0bf00003c04.png">
<img width="302" alt="Screen Shot 2020-03-27 at 2 34 10 PM" src="https://user-images.githubusercontent.com/55107443/77788711-1f126480-7038-11ea-9116-dd10fa414f68.png">
<img width="223" alt="Screen Shot 2020-03-27 at 2 34 13 PM" src="https://user-images.githubusercontent.com/55107443/77788712-1f126480-7038-11ea-99ba-84d56003b9ae.png">
